### PR TITLE
update misspelled "secrectkey" to "secretkey"

### DIFF
--- a/cryptojs/decrypt.js
+++ b/cryptojs/decrypt.js
@@ -10,8 +10,8 @@ module.exports = function (RED) {
 
 		node.on('input', function (msg) {
 			// first check if secret key was sent via msg first. If true overwrite user entered secret key in configuration.
-			if(msg.secrectkey) {
-				node.key = msg.secrectkey;
+			if(msg.secretkey) {
+				node.key = msg.secretkey;
 			}
 			// check configurations
 			if(!node.algorithm || !node.key) {

--- a/cryptojs/encrypt.js
+++ b/cryptojs/encrypt.js
@@ -10,8 +10,8 @@ module.exports = function (RED) {
 
 		node.on('input', function (msg) {
 			// first check if secret key was sent via msg first. If true overwrite user entered secret key in configuration.
-			if(msg.secrectkey) {
-				node.key = msg.secrectkey;
+			if(msg.secretkey) {
+				node.key = msg.secretkey;
 			}
 			// check configurations
 			if(!node.algorithm || !node.key) {

--- a/cryptojs/hmac.js
+++ b/cryptojs/hmac.js
@@ -10,8 +10,8 @@ module.exports = function (RED) {
 
 		node.on('input', function (msg) {
 			// first check if secret key was sent via msg first. If true overwrite user entered secret key in configuration.
-			if(msg.secrectkey) {
-				node.key = msg.secrectkey;
+			if(msg.secretkey) {
+				node.key = msg.secretkey;
 			}
 			// check configurations
 			if(!node.algorithm || !node.key) {


### PR DESCRIPTION
I was debugging it for a while. `msg.secretkey` that can be overridden in `encrypt.js` `decrypt.js` and `hmac.js` was misspelled as `secrectkey`.